### PR TITLE
Add documentation for custom RHAI functions (see issue #3)

### DIFF
--- a/src/script/rhai_modules/rhai_file.rs
+++ b/src/script/rhai_modules/rhai_file.rs
@@ -18,7 +18,6 @@ use simple_fs::{ensure_file_dir, list_files};
 use std::fs::write;
 use std::path::Path;
 
-/// Define the `file` module and register functions
 pub fn rhai_module() -> Module {
 	// Create a module for text functions
 	let mut module = Module::new();

--- a/src/script/rhai_modules/rhai_file.rs
+++ b/src/script/rhai_modules/rhai_file.rs
@@ -1,3 +1,15 @@
+//! Defines the `file` module, used in the rhai engine. 
+//! 
+//! ---
+//! 
+//! ## RHAI documentation
+//! The `file` module exposes functions used to read, write, or modify files.
+//! 
+//! ### Functions
+//! * `load(file_path: string) -> FileRecord`
+//! * `save(file_path: string, content: string)`
+//! * `list(glob: string) -> Vec<FileRef>`
+
 use crate::types::{FileRecord, FileRef};
 use crate::Result;
 use rhai::plugin::RhaiResult;
@@ -6,6 +18,7 @@ use simple_fs::{ensure_file_dir, list_files};
 use std::fs::write;
 use std::path::Path;
 
+/// Define the `file` module and register functions
 pub fn rhai_module() -> Module {
 	// Create a module for text functions
 	let mut module = Module::new();
@@ -27,6 +40,13 @@ pub fn rhai_module() -> Module {
 
 // region:    --- Rhai Functions
 
+/// ## RHAI Documentation
+/// ```rhai
+/// list(glob: string) -> Vec<FileRef>
+/// ```
+/// 
+/// Expands `glob`, returning a list of all matching file paths along with
+/// helpful metadata.
 fn list_with_glob(include_glob: &str) -> RhaiResult {
 	let sfiles = list_files("./", Some(&[include_glob]), None).map_err(|err| {
 		EvalAltResult::ErrorRuntime(
@@ -42,6 +62,13 @@ fn list_with_glob(include_glob: &str) -> RhaiResult {
 	Ok(res_dynamic)
 }
 
+/// ## RHAI Documentation
+/// ```rhai
+/// load(file_path: string) -> FileRecord
+/// ```
+/// 
+/// Reads the file specified by `path`, returning the contents of the file
+/// along with helpful metadata.
 fn load(file_path: &str) -> RhaiResult {
 	let file_record = FileRecord::new(file_path);
 	match file_record {
@@ -53,6 +80,12 @@ fn load(file_path: &str) -> RhaiResult {
 	}
 }
 
+/// ## RHAI Documentation
+/// ```rhai
+/// save(file_path: string, content: string)
+/// ```
+/// 
+/// Writes `content` to the specified `file_path`.
 fn save(file_path: &str, content: &str) -> RhaiResult {
 	fn file_save_inner(file_path: &str, content: &str) -> Result<()> {
 		// let sfile = SFile::from_path(file_path)?;

--- a/src/script/rhai_modules/rhai_git.rs
+++ b/src/script/rhai_modules/rhai_git.rs
@@ -1,3 +1,14 @@
+//! Defines the `git` module, used in the rhai engine.
+//! 
+//! ---
+//! 
+//! ## RHAI documentation
+//! 
+//! The `git` module exposes functions that call `git` commands.
+//! 
+//! ### Functions
+//! * `restore(file_path: string) -> string`
+
 use rhai::plugin::RhaiResult;
 use rhai::{FuncRegistration, Module};
 
@@ -14,6 +25,13 @@ pub fn rhai_module() -> Module {
 
 // region:    --- Functions
 
+/// ## RHAI Documentation
+/// ```rhai
+/// restore(file_path: string) -> string
+/// ```
+/// 
+/// Calls `git restore {file_path}` and returns the output (stdout) of that 
+/// call.
 fn git_restore(path: &str) -> RhaiResult {
 	let output = std::process::Command::new("git")
 		.arg("restore")

--- a/src/script/rhai_modules/rhai_md.rs
+++ b/src/script/rhai_modules/rhai_md.rs
@@ -1,3 +1,13 @@
+//! Defines the `md` module, used in the rhai engine. 
+//! 
+//! ## RHAI Documentation
+//! The `md` module exposes functions that process markdown content. Useful for
+//! processing LLM responses.
+//! 
+//! ### Functions
+//! * `extract_blocks(md_content: string) -> Vec<MdBlock>`
+//! * `extract_blocks(md_content: string, lang_name: string) -> Vec<MdBlock>`
+
 use crate::support::md;
 use crate::types::MdBlock;
 use rhai::plugin::RhaiResult;
@@ -20,12 +30,28 @@ pub fn rhai_module() -> Module {
 
 // region:    --- Rhai Functions
 
+/// ## RHAI Documentation
+/// ```rhai
+/// extract_blocks(md_content: string) -> Vec<MdBlock>
+/// ```
+/// 
+/// Parses the markdown provided by `md_content` and extracts each code block, 
+/// returning a list of blocks.
 fn extract_blocks(md_content: &str) -> RhaiResult {
 	let blocks = md::extract_blocks(md_content, None);
 	let blocks: Vec<Dynamic> = blocks.into_iter().map(MdBlock::into_dynamic).collect();
 	Ok(blocks.into())
 }
 
+/// ## RHAI Documentation
+/// ```rhai
+/// extract_blocks(md_content: &str, lang_name: &str) -> Vec<MdBlock>
+/// ```
+/// 
+/// Parses the markdown provided by `md_content` and extracts each code block,
+/// returning only the blocks with a 
+/// [language identifier](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting)
+/// that matches `lang_name`.
 fn extract_blocks_with_name(md_content: &str, lang_name: &str) -> RhaiResult {
 	let blocks = md::extract_blocks(md_content, Some(lang_name));
 	let blocks: Vec<Dynamic> = blocks.into_iter().map(MdBlock::into_dynamic).collect();

--- a/src/script/rhai_modules/rhai_text.rs
+++ b/src/script/rhai_modules/rhai_text.rs
@@ -155,6 +155,7 @@ fn escape_decode_if_needed(content: &str) -> RhaiResult {
 	}
 }
 
+// html-escape
 /// ## RHAI Documentation
 /// ```rhai
 /// escape_decode(content: string) -> string

--- a/src/script/rhai_modules/rhai_text.rs
+++ b/src/script/rhai_modules/rhai_text.rs
@@ -1,3 +1,18 @@
+//! Defines the `text` module, used in the rhai engine
+//! 
+//! ---
+//! 
+//! ## RHAI documentation
+//! This module exposes functions that process text.
+//! 
+//! ### Functions
+//! * `escape_decode(content: string) -> string`
+//! * `escape_decode_if_needed(content: string) -> string`
+//! * `remove_first_line(content: string) -> string`
+//! * `remove_first_lines(content: string, n: int) -> string`
+//! * `remove_last_line(content: string) -> string`
+//! * `remove_last_lines(content: string, n: int) -> string`
+
 use crate::support::decode_html_entities;
 use rhai::plugin::RhaiResult;
 use rhai::{FuncRegistration, Module};
@@ -37,10 +52,22 @@ pub fn rhai_module() -> Module {
 
 // region:    --- Strings
 
+///  ## RHAI Documentation
+/// ```rhai
+/// remove_first_line(content: string) -> string
+/// ```
+/// 
+/// Returns `content` with the first line removed.
 fn remove_first_line(content: &str) -> &str {
 	remove_first_lines(content, 1)
 }
 
+///  ## RHAI Documentation
+/// ```rhai
+/// remove_first_lines(content: string, n: int) -> string
+/// ```
+/// 
+/// Returns `content` with the first `n` lines removed.
 fn remove_first_lines(content: &str, num_of_lines: usize) -> &str {
 	let mut start_idx = 0;
 	let mut newline_count = 0;
@@ -65,10 +92,22 @@ fn remove_first_lines(content: &str, num_of_lines: usize) -> &str {
 	&content[start_idx..]
 }
 
+///  ## RHAI Documentation
+/// ```rhai
+/// remove_last_line(content: string) -> string
+/// ```
+/// 
+/// Returns `content` with the last line removed.
 fn remove_last_line(content: &str) -> &str {
 	remove_last_lines(content, 1)
 }
 
+///  ## RHAI Documentation
+/// ```rhai
+/// remove_last_lines(content: string, n: int) -> string
+/// ```
+/// 
+/// Returns `content` with the last `n` lines removed.
 fn remove_last_lines(content: &str, num_of_lines: usize) -> &str {
 	let mut end_idx = content.len(); // Start with the end of the string
 	let mut newline_count = 0;
@@ -98,6 +137,16 @@ fn remove_last_lines(content: &str, num_of_lines: usize) -> &str {
 // region:    --- Escape Fns
 
 /// Only escape if needed. right now, the test only test `&lt;`
+/// 
+/// ## RHAI Documentation
+/// ```rhai
+/// escape_decode(content: string) -> string
+/// ```
+/// 
+/// Some LLMs HTML-encode their responses. This function returns `content` 
+/// after selectively decoding certain HTML tags. 
+/// 
+/// Right now, the only tag that gets decoded is `&lt;`.
 fn escape_decode_if_needed(content: &str) -> RhaiResult {
 	if !content.contains("&lt;") {
 		Ok(content.into())
@@ -106,7 +155,13 @@ fn escape_decode_if_needed(content: &str) -> RhaiResult {
 	}
 }
 
-// html-escape
+/// ## RHAI Documentation
+/// ```rhai
+/// escape_decode(content: string) -> string
+/// ```
+/// 
+/// Some LLMs HTML-encode their responses. This function returns `content`, 
+/// HTML-decoded.
 fn escape_decode(content: &str) -> RhaiResult {
 	let decoded = decode_html_entities(content);
 	Ok(decoded.into())


### PR DESCRIPTION
The "src/script/rhai_modules" directory defines modules that get registered to the RHAI runtime. With this PR, I hope to provide helpful documentation for these modules.

The names, behavior, and signatures of the RHAI functions are similar to, but distinct from, their corresponding Rust functions. To clearly distinguish documentation for RHAI functions from their corresponding Rust functions' documentation, I preceded each block of RHAI documentation with the header `## RHAI Documentation`.

**Example**
```rust
// src/script/rhai_modules/rhai_text.rs - ln. 139

/// Only escape if needed. right now, the test only test `&lt;`              <--- Preexisting documentation for the _Rust_ function
/// 
/// ## RHAI Documentation                                                    <--- Documentation for the corresponding _RHAI_ function
/// ```rhai
/// escape_decode(content: string) -> string                                 <--- Note that the RHAI function has a slightly different signature than the Rust function
/// ```
/// 
/// Some LLMs HTML-encode their responses. This function returns `content` 
/// after selectively decoding certain HTML tags. 
fn escape_decode_if_needed(content: &str) -> RhaiResult {
```