### PR TITLE
"rhai_devai.rs" module documentation. Related to #3.

### DIFF
--- a/src/script/rhai_script/rhai_modules/rhai_devai.rs
+++ b/src/script/rhai_script/rhai_modules/rhai_devai.rs
@@ -1,3 +1,15 @@
+//! Defines the `devai` module, used in the rhai engine
+//! 
+//! ---
+//! 
+//! ## RHAI documentation
+//! The `devai` module exposes functions that modify the default flow of the
+//! devai parser and script runner.
+//! 
+//! ### Functions
+//! * `action_skip() -> SkipActionDict`
+//! * `action_skip(reason: string) -> SkipActionDict`
+
 use crate::script::rhai_script::helpers::serde_value_to_dynamic;
 use rhai::plugin::RhaiResult;
 use rhai::{FuncRegistration, Module};


### PR DESCRIPTION
Tiny commit to add an "RHAI Documentation" section to the module-level documentation for the `rhai_devai` module. The documentation is consistent with the module-level documentation for the other rhai modules.

