### PR TITLE
Preventing watch for occuring all the time

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -52,7 +52,11 @@ impl CliCommand {
 	/// For now, for all Run and Solo, the interactive is on by default, regardless if it watch.
 	pub fn is_interactive(&self) -> bool {
 		match self {
-			CliCommand::Run(_) => true,
+			CliCommand::Run(_) => if let CliCommand::Run(run_args) = self {
+                run_args.watch
+            } else {
+                false
+            },
 			CliCommand::Solo(_) => true,
 			CliCommand::Init(_) => false,
 			CliCommand::InitBase => false,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -53,10 +53,10 @@ impl CliCommand {
 	pub fn is_interactive(&self) -> bool {
 		match self {
 			CliCommand::Run(_) => if let CliCommand::Run(run_args) = self {
-                run_args.watch
-            } else {
-                false
-            },
+				run_args.watch
+			} else {
+				false
+			},
 			CliCommand::Solo(_) => true,
 			CliCommand::Init(_) => false,
 			CliCommand::InitBase => false,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -52,11 +52,7 @@ impl CliCommand {
 	/// For now, for all Run and Solo, the interactive is on by default, regardless if it watch.
 	pub fn is_interactive(&self) -> bool {
 		match self {
-			CliCommand::Run(_) => if let CliCommand::Run(run_args) = self {
-				run_args.watch
-			} else {
-				false
-			},
+			CliCommand::Run(run_args) => run_args.watch,
 			CliCommand::Solo(_) => true,
 			CliCommand::Init(_) => false,
 			CliCommand::InitBase => false,


### PR DESCRIPTION
I was trying to use `devai` in a nushell script `each { |f| devai run <prompt> $f }`
it failed as devai always started in watch mood.