### PR TITLE
Adding --not-interactive / --in cli flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ devai init
 # Will proofread and update the direct .md file from the current directory
 devai run proof-read -f "./*.md"
 # Can use multiple globs or direct files -f "./*.md" -f "./doc/**/*.md"
+
+# For a one shot run
+devai run --non-interactive proof-read -f "./doc/README.md"
+
+# or
+devai run --ni proof-read -f "./doc/README.md"
 ```
 
 The main **devai** concept is to minimize the friction of creating and running an agent while providing maximum control over how we want those agents to run and maximizing iteration speed to mature them quickly.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -52,7 +52,7 @@ impl CliCommand {
 	/// For now, for all Run and Solo, the interactive is on by default, regardless if it watch.
 	pub fn is_interactive(&self) -> bool {
 		match self {
-			CliCommand::Run(_) => true,
+			CliCommand::Run(run_args) => !run_args.not_interactive,
 			CliCommand::Solo(_) => true,
 			CliCommand::Init(_) => false,
 			CliCommand::InitBase => false,
@@ -97,6 +97,10 @@ pub struct RunArgs {
 	/// Dry mode, takes either 'req' or 'res'
 	#[arg(long = "dry", value_parser = ["req", "res"])]
 	pub dry_mode: Option<String>,
+
+    /// Non-interactive mode (one-shot execution)
+    #[arg(long = "not-interactive", alias = "ni")]
+    pub not_interactive: bool,
 }
 
 /// Arguments for the `solo` subcommand


### PR DESCRIPTION
Add --not-interactive / --ni CLI Flag for Non-Interactive Mode

## Summary

This pull request introduces a new CLI flag, --not-interactive (alias: --ni), for the run command. This flag enables a one-shot execution mode, bypassing the default interactive behavior.

## Changes
1.	README Update:
	-	Added documentation for the --not-interactive / --ni flag, including examples of usage for the run command.
2.	CLI Argument Enhancements:
	-	Modified RunArgs to include a not_interactive flag, which can be set via --not-interactive or --ni.
	-	Updated the is_interactive method in CliCommand to respect the new flag.

## Usage Examples

### Example 1: One-shot execution
```sh
devai run --not-interactive proof-read -f "./doc/README.md"
```

### Example 2: Alias for the flag
```sh
devai run --ni proof-read -f "./doc/README.md"
```

## Rationale

This change enhances usability by offering a non-interactive mode for users who need one-shot executions, improving automation and script integration workflows.

## Testing
	-	Verified default interactive behavior remains unchanged.
	-	Tested the --not-interactive flag and its alias in various scenarios to confirm the expected behavior.
