### PR TITLE
cmd.exe /c for code invocation

### DIFF
--- a/src/exec/support.rs
+++ b/src/exec/support.rs
@@ -7,15 +7,31 @@ use std::process::Command;
 /// NOTE: VSCode will do the right thing when the user have multiple vscode open
 ///       by opening the path in the corresponding workspace.
 pub async fn open_vscode(path: impl AsRef<Path>) {
-	let path = path.as_ref();
+    let path = path.as_ref();
 
-	let output = Command::new("code")
-		.arg(path)
-		.output()
-		.expect("Failed to execute VSCode 'code' command");
+    let output = if cfg!(target_os = "windows") {
+        Command::new("cmd")
+            .args(&["/C", "code", path.to_str().unwrap()])
+            .output()
+    } else {
+        Command::new("code")
+            .arg(path)
+            .output()
+    };
 
-	if !output.status.success() {
-		let msg = format!("Error opening VSCode: {}", String::from_utf8_lossy(&output.stderr));
-		get_hub().publish(Error::Custom(msg.to_string())).await;
-	}
+    match output {
+        Ok(output) if output.status.success() => {}
+        Ok(output) => {
+            let msg = format!(
+                "Error opening VSCode:\nstdout: {}\nstderr: {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            get_hub().publish(Error::Custom(msg)).await;
+        }
+        Err(e) => {
+            let msg = format!("Failed to execute VSCode command: {}", e);
+            get_hub().publish(Error::Custom(msg)).await;
+        }
+    }
 }


### PR DESCRIPTION
It shouldn't happen but the extra error code can come out if preference.  this makes 'a' work on windows.