### PR TITLE
+ devai_config module for getting .devai\config.toml values from lua. +utils.path.join()

### DIFF
--- a/_init/agents/craft/lua/craft.lua
+++ b/_init/agents/craft/lua/craft.lua
@@ -73,6 +73,16 @@ function prep_inst_and_content(content, separator, is_content_default)
   return inst, content
 end
 
+-- Access .devai/config.toml in Lua
+if devai_config then
+    print("Loaded Devai Config:")
+    for key, value in pairs(devai_config) do
+        print(key, value)
+    end
+else
+    print("Error: devai_config is not available!")
+end
+
 return {
   prep_input_file = prep_input_file,
   should_skip = should_skip,

--- a/src/run/dir_context/devai_dir.rs
+++ b/src/run/dir_context/devai_dir.rs
@@ -22,6 +22,9 @@ pub struct DevaiDir {
 
 //
 impl DevaiDir {
+	pub fn dir_full_path(&self) -> &SPath {
+		&self.devai_dir_full_path
+	}
 	pub fn from_parent_dir(parent_dir: impl AsRef<Path>) -> Result<Self> {
 		let workspace_dir = SPath::from_path(parent_dir)?;
 		// Note: Here we use the `./.devai` which is fixed, and the `./`

--- a/src/script/lua_script/devai_config.rs
+++ b/src/script/lua_script/devai_config.rs
@@ -1,0 +1,55 @@
+use crate::run::RuntimeContext;
+use mlua::Lua;
+use mlua::Table;
+use simple_fs::{list_files, read_to_string, SFile, SPath};
+use crate::support::tomls::parse_toml;
+
+/// Convert JSON to Lua Table
+fn json_to_lua_table(lua: &Lua, json_value: &serde_json::Value) -> mlua::Result<Table> {
+    let table = lua.create_table()?;
+    match json_value {
+        serde_json::Value::Object(map) => {
+            for (key, value) in map {
+                match value {
+                    serde_json::Value::String(s) => table.set(key.as_str(), s.as_str())?,
+                    serde_json::Value::Number(n) => table.set(key.as_str(), n.as_f64().unwrap_or(0.0))?,
+                    serde_json::Value::Bool(b) => table.set(key.as_str(), *b)?,
+                    serde_json::Value::Array(arr) => {
+                        let arr_table = lua.create_table()?;
+                        for (i, item) in arr.iter().enumerate() {
+                            match item {
+                                serde_json::Value::String(s) => arr_table.set(i + 1, s.as_str())?,
+                                serde_json::Value::Number(n) => arr_table.set(i + 1, n.as_f64().unwrap_or(0.0))?,
+                                serde_json::Value::Bool(b) => arr_table.set(i + 1, *b)?,
+                                _ => {}
+                            }
+                        }
+                        table.set(key.as_str(), arr_table)?;
+                    }
+                    serde_json::Value::Object(_) => {
+                        let sub_table = json_to_lua_table(lua, value)?;
+                        table.set(key.as_str(), sub_table)?;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(table)
+}
+
+/// Initialize `devai_config` from `AgentConfig`
+pub fn init_module(lua: &Lua, runtime_context: &RuntimeContext) -> mlua::Result<()> {
+ 	let config_path = runtime_context.dir_context().devai_dir().get_config_toml_path()?;
+	let config_content = read_to_string(config_path).unwrap_or_default();
+	let config_value = parse_toml(&config_content).unwrap_or_default();
+    let lua_table = json_to_lua_table(lua, &config_value)?;
+
+    // Inject into Lua as `devai_config`
+    lua.globals().set("devai_config", lua_table)?;
+     println!("✅ devai_config injected into Lua.");
+
+
+    Ok(())
+}

--- a/src/script/lua_script/lua_engine.rs
+++ b/src/script/lua_script/lua_engine.rs
@@ -5,6 +5,7 @@ use crate::script::lua_script::{
 	utils_cmd, utils_devai, utils_file, utils_git, utils_html, utils_json, utils_lua, utils_md, utils_path, utils_rust,
 	utils_text, utils_web,
 };
+use crate::script::lua_script::devai_config;
 use crate::{Error, Result};
 use mlua::{Lua, LuaSerdeExt, Table, Value};
 
@@ -24,6 +25,8 @@ impl LuaEngine {
 
 		// -- init devai
 		utils_devai::init_module(&lua, &runtime_context)?;
+
+		devai_config::init_module(&lua, &runtime_context)?;
 
 		// -- Init package.path
 		init_package_path(&lua, &runtime_context)?;

--- a/src/script/lua_script/mod.rs
+++ b/src/script/lua_script/mod.rs
@@ -13,6 +13,7 @@ mod utils_path;
 mod utils_rust;
 mod utils_text;
 mod utils_web;
+mod devai_config;
 
 mod lua_engine;
 


### PR DESCRIPTION
using utils.path.join is a must for cross-platform devai scripts.  it works for tables and strings...pretty neat.
I added devai_config module.  we spoke briefly about the utils module.  this is my first attempt at pushing towards a devai lua module(s).

next, I saw you had some toml code that went to json and your preference for json being lingua.  so I've used that and a json to lua table for the config.toml.  json_to_lua_table probably belongs in utils_json.rs.  I hesitate to add more to utils. I'm some what don't understand what is gained by not going from toml to lua table.

> Note: The goal is that all get serialized to serded_json as this is the cannonical format for now.

there was another note somewhere about how the selection was a win...can't find it now but would be interested in the details on the win.  What was the point of SPath instead of just PathBuf directly?

```
/// An SPath can be constructed from a String, Path, io::DirEntry, or walkdir::DirEntry
/// and guarantees the path is UTF-8, simplifying many apis.
#[derive(Debug, Clone)]
pub struct SPath {
	pub(crate) path_buf: PathBuf,
}
```

the _init/agents/craft/lua/craft.lua I added some code and thought if I added it to my craft.lua it would run automatically.  I did this in my custom/lua/craft.lua and my default/agent/craft/lua/craft.lua.  I could have left it out and I will happily pull it out for you; I figured I'd ask for the background here...maybe I should create a craft.lua discussion item.

anyway that was fun. have a good day.