### PR TITLE
simple path fix.

### DIFF
--- a/src/agent/agent_locator.rs
+++ b/src/agent/agent_locator.rs
@@ -308,21 +308,21 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_get_solo_and_target_path() -> Result<()> {
-		let data = &[
-			// (path, expected_solo_path, expected_target_path)
-			("./some/file.md", "./some/file.md.devai", "./some/file.md"),
-			("./some/file.md.devai", "./some/file.md.devai", "./some/file.md"),
-			("./some/file.devai", "./some/file.devai", "./some/file.md"),
-		];
+    	let data = &[
+        	// (input path, expected solo path, expected target path)
+        	("./some/file.md", "./some/file.md.devai", "./some/file.md"),
+        	("./some/file.md.devai", "./some/file.md.devai", "./some/file.md"),
+        	("./some/file.devai", "./some/file.devai", "./some/file.md"),
+    	];
 
-		// -- Exec & Check
-		for (path, expected_solo_path, expected_target_path) in data {
-			let (solo_path, target_path) = get_solo_and_target_path(path)?;
-			assert_eq!(solo_path.to_str(), *expected_solo_path);
-			assert_eq!(target_path.to_str(), *expected_target_path);
-		}
+    	for (path, expected_solo_path, expected_target_path) in data {
+        	let (solo_path, target_path) = get_solo_and_target_path(path)?;
+        	// Compare the Path objects directly.
+        	assert_eq!(solo_path.path(), Path::new(expected_solo_path));
+        	assert_eq!(target_path.path(), Path::new(expected_target_path));
+    	}
 
-		Ok(())
+    	Ok(())
 	}
 
 	#[tokio::test]

--- a/tests-data/sandbox-01/solo/simple.md
+++ b/tests-data/sandbox-01/solo/simple.md
@@ -1,1 +1,1 @@
-Output - ./solo/simple.md - From Data (input.path: ./solo/simple.md
+Output - ./solo\simple.md - From Data (input.path: ./solo\simple.md


### PR DESCRIPTION
I should have additional fixes to come.  with your commits of the config in sandbox and this fix I'm at 13.
They are all this.  Now I would really like to write a devai agent to scan the codebase for this pattern and make the change.
how hard do you think this would be?  I can easily get these tests fixed.  the devai way is what makes this interesting.

exploring the workflow is more interesting than this simple pathing issue.  if you have ideas on how to write an agent to do this lmk; i think with some thought I can come up with something but would do better with your knowledge. thanks.

You can compare paths as Path objects directly. This way you avoid issues with OS-specific separators.