### PR TITLE
util.hbs.render for rendering handlebars from lua using lua tables for context.

### DIFF
--- a/.devai/default/tests/test-hbs.devai
+++ b/.devai/default/tests/test-hbs.devai
@@ -1,0 +1,96 @@
+# config
+
+```toml
+[genai]
+model = "test_model_for_demo"
+```
+
+# Before All 
+
+```lua
+-- let before_all = "before_all";
+```
+
+# Data
+
+```lua
+-- let some_data = "Some Data";
+-- return some_data;
+print("dave")
+-- Define the save_path variable as needed.
+-- For example:
+local save_path = "."
+
+-- Test 1: Simple Rendering
+local tmpl1 = "Hello, {{name}}!"
+local data1 = { name = "Alice" }
+local result1 = utils.hbs.render(tmpl1, data1)
+assert(result1 == "Hello, Alice!", "Test 1 Failed: Expected 'Hello, Alice!', got " .. tostring(result1))
+local test1 = utils.path.join(save_path, "tests", "test1.txt")
+utils.file.save(test1, result1)
+print("Test 1 Passed: Simple rendering.")
+
+-- Test 2: Missing Field
+local tmpl2 = "Hello, {{name}}! Your age is {{age}}."
+local data2 = { name = "Bob" }
+-- In Handlebars, missing fields typically render as an empty string.
+local result2 = utils.hbs.render(tmpl2, data2)
+assert(result2 == "Hello, Bob! Your age is .", "Test 2 Failed: Expected 'Hello, Bob! Your age is .', got " .. tostring(result2))
+local test2 = utils.path.join(save_path, "tests", "test2.txt")
+utils.file.save(test2, result2)
+print("Test 2 Passed: Missing field handled correctly.")
+
+-- Test 3: Nested Data
+local tmpl3 = "Name: {{name}}, City: {{address.city}}"
+local data3 = { name = "Charlie", address = { city = "Wonderland" } }
+local result3 = utils.hbs.render(tmpl3, data3)
+assert(result3 == "Name: Charlie, City: Wonderland", "Test 3 Failed: Expected 'Name: Charlie, City: Wonderland', got " .. tostring(result3))
+local test3 = utils.path.join(save_path, "tests", "test3.txt")
+utils.file.save(test3, result3)
+print("Test 3 Passed: Nested data rendering.")
+
+-- Test 4: Using Multiple Fields
+local tmpl4 = "User: {{name}}, Email: {{email}}"
+local data4 = { name = "Dana", email = "dana@example.com" }
+local result4 = utils.hbs.render(tmpl4, data4)
+assert(result4 == "User: Dana, Email: dana@example.com", "Test 4 Failed: Expected 'User: Dana, Email: dana@example.com', got " .. tostring(result4))
+local test4 = utils.path.join(save_path, "tests", "test4.txt")
+utils.file.save(test4, result4)
+print("Test 4 Passed: Multiple fields rendered correctly.")
+
+-- Test 5: Error Handling (Invalid Data)
+local tmpl5 = "Hello, {{name}}!"
+local bad_data = "this should be a table"
+local success, err = pcall(function()
+    utils.hbs.render(tmpl5, bad_data)
+end)
+assert(not success, "Test 5 Failed: Expected failure when passing non-table data.")
+print("Test 5 Passed: Properly failed when given invalid data.")
+
+-- Test 6: Automatic Table Conversion
+-- Here, we pass a table for the 'body' field that contains a "content" field.
+local tmpl6 = "Body: {{body}}"
+local data6 = { body = { content = "<p>This HTML comes from a table</p>" } }
+local result6 = utils.hbs.render(tmpl6, data6)
+assert(result6 == "Body: <p>This HTML comes from a table</p>", "Test 6 Failed: Expected 'Body: <p>This HTML comes from a table</p>', got " .. tostring(result6))
+local test6 = utils.path.join(save_path, "tests", "test6.txt")
+utils.file.save(test6, result6)
+print("Test 6 Passed: Automatic table conversion for 'body' field.")
+
+print("All tests passed!")
+```
+
+# Instruction
+
+Some instruction
+
+# Output
+
+```lua
+```
+
+# After All
+
+```lua
+let after_all = "after_all";
+```

--- a/src/script/lua_script/lua_engine.rs
+++ b/src/script/lua_script/lua_engine.rs
@@ -2,8 +2,8 @@ use crate::hub::{get_hub, HubEvent};
 use crate::run::path_consts::CUSTOM_LUA_DIR;
 use crate::run::{get_devai_base_dir, RuntimeContext};
 use crate::script::lua_script::{
-	utils_cmd, utils_devai, utils_file, utils_git, utils_html, utils_json, utils_lua, utils_md, utils_path,
-	utils_rust, utils_text, utils_code, utils_web,
+	utils_cmd, utils_code, utils_devai, utils_file, utils_git, utils_hbs, utils_html, utils_json, utils_lua, utils_md,
+	utils_path, utils_rust, utils_text, utils_web,
 };
 use crate::{Error, Result};
 use mlua::{IntoLua, Lua, LuaSerdeExt, Table, Value};
@@ -218,6 +218,7 @@ fn init_utils(lua_vm: &Lua, runtime_context: &RuntimeContext) -> Result<()> {
 		lua_vm,
 		runtime_context,
 		// -- The lua module names that refers to utils_...
+		hbs,
 		file,
 		git,
 		web,

--- a/src/script/lua_script/mod.rs
+++ b/src/script/lua_script/mod.rs
@@ -2,9 +2,11 @@
 
 mod helpers;
 mod utils_cmd;
+mod utils_code;
 mod utils_devai;
 mod utils_file;
 mod utils_git;
+mod utils_hbs;
 mod utils_html;
 mod utils_json;
 mod utils_lua;
@@ -12,7 +14,6 @@ mod utils_md;
 mod utils_path;
 mod utils_rust;
 mod utils_text;
-mod utils_code;
 mod utils_web;
 
 mod lua_engine;

--- a/src/script/lua_script/utils_hbs.rs
+++ b/src/script/lua_script/utils_hbs.rs
@@ -1,0 +1,122 @@
+//! Defines the `hbs` module for Lua Handlebars integration.
+//!
+//! ## Lua Documentation
+//! The `hbs` module exposes functions that render Handlebars templates with
+//! provided data. This is useful for dynamically generating content within Lua scripts.
+//!
+//! ### Functions
+//! * `hbs.render(hbs_tmpl: string, data: table) -> string`
+
+use crate::run::RuntimeContext;
+use crate::support::hbs::hbs_render;
+use crate::Result;
+use handlebars::JsonValue;
+use mlua::{Lua, Table, Value};
+use std::collections::HashMap;
+
+/// Initializes the Handlebars module for Lua.
+///
+/// This function creates a Lua table with the available Handlebars functions.
+/// Register this table under a namespace (for example, `utils.hbs`) to make the
+/// functions available in your Lua scripts.
+pub fn init_module(lua: &Lua, _runtime_context: &RuntimeContext) -> mlua::Result<Table> {
+	let table = lua.create_table()?;
+	let render_fn = lua.create_function(lua_hbs_render)?;
+	table.set("render", render_fn)?;
+	Ok(table)
+}
+
+/// Renders a Handlebars template using provided data.
+///
+/// ### Lua Documentation
+/// ```lua
+/// -- Render a template using a data table
+/// local tmpl = "Hello, {{name}}!"
+/// local data = { name = "Alice" }
+/// local result = utils.hbs.render(tmpl, data)
+/// print(result)  -- Output: Hello, Alice!
+/// ```
+///
+/// # Parameters:
+/// - `hbs_tmpl` (string): The Handlebars template string.
+/// - `data` (table): A table containing key-value pairs for the template.
+///
+/// # Returns:
+/// - (string): The rendered template.
+
+fn lua_hbs_render(lua: &mlua::Lua, (hbs_tmpl, data): (String, mlua::Table)) -> mlua::Result<String> {
+	// Convert the Lua table to a serde_json::Value using serde_json::to_value.
+	let data_json: serde_json::Value = serde_json::to_value(data)
+		.map_err(|e| mlua::Error::external(format!("Failed to convert Lua table to JSON: {}", e)))?;
+
+	// Convert the JSON object into a HashMap.
+	let mut data_map: std::collections::HashMap<String, serde_json::Value> = match data_json {
+		serde_json::Value::Object(map) => map.into_iter().collect(),
+		_ => return Err(mlua::Error::external("Expected a JSON object for data")),
+	};
+
+	// Helper function to process JSON values while preserving nested objects.
+	fn process_value(val: serde_json::Value) -> serde_json::Value {
+		match val {
+			serde_json::Value::Object(mut obj) => {
+				if let Some(serde_json::Value::String(content)) = obj.get("content") {
+					serde_json::Value::String(content.clone()) // Extract "content" field if present
+				} else {
+					serde_json::Value::Object(
+						obj.into_iter()
+							.map(|(k, v)| (k, process_value(v))) // Recursively process nested objects
+							.collect(),
+					)
+				}
+			}
+			serde_json::Value::Array(arr) => serde_json::Value::Array(arr.into_iter().map(process_value).collect()),
+			serde_json::Value::String(_) => val,             // Keep strings unchanged
+			_ => serde_json::Value::String(val.to_string()), // Convert other types to strings
+		}
+	}
+
+	// Iterate over the data_map and process each value.
+	for (_k, v) in data_map.iter_mut() {
+		*v = process_value(v.take());
+	}
+
+	// Render the Handlebars template using the updated data_map.
+	let rendered = hbs_render(&hbs_tmpl, &data_map)
+		.map_err(|e| mlua::Error::external(format!("Handlebars render error: {}", e)))?;
+	Ok(rendered)
+}
+
+// region: --- Tests
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::run::Runtime;
+	use mlua::Lua;
+
+	#[tokio::test]
+	async fn test_lua_hbs_render() -> Result<()> {
+		// Setup a test runtime and Lua engine.
+		let runtime = Runtime::new_test_runtime_sandbox_01()?;
+		let lua_engine = runtime.new_lua_engine()?;
+		let globals = lua_engine.globals();
+
+		// Initialize the hbs module and register it under the globals.
+		let hbs_module = init_module(&lua_engine)?;
+		globals.set("hbs", hbs_module)?;
+
+		// Lua script to render a Handlebars template.
+		let lua_script = r#"
+            local tmpl = "Hello, {{name}}!"
+            local data = { name = "Alice" }
+            return hbs.render(tmpl, data)
+        "#;
+
+		let result: String = lua_engine.load(lua_script).eval()?;
+		assert_eq!(result, "Hello, Alice!");
+
+		Ok(())
+	}
+}
+
+// endregion: --- Tests


### PR DESCRIPTION
I tried to get it to support complex objects and also manage to pull strings out of tables from .content fields.

.devai/default/tests/test-hbs.devai is a test.  the commented lines in the sections are bugs I think; I also found myself in a headache of a problem with the config.toml thing it was legacy and always recreating itself.

I had to comment out; its super broken on windows.
```
    ⋮ 57 │        //let is_new_version = check_is_new_version(&devai_dir).await?;
    ⋮ 58 │        //create_or_refresh_devai_files(&devai_dir, is_new_version).await?;
```
i'll look at it another day.

I don't know where we should keep them, but I think a directory of lua tests should go somewhere.